### PR TITLE
Don't qualify IDs, don't use multiple elements w/ same ID, and more!

### DIFF
--- a/levels.js
+++ b/levels.js
@@ -43,7 +43,7 @@ var levels = [
     help : 'Selects an element with that id. You can also combine the ID selector with the type selector.',
     examples : [
       '<strong>#cool</strong> will select any element with <strong>id="cool"</strong>',
-      '<strong>ul#long</strong> will select <strong>&lt;ul id="long"&gt;</strong>'
+      '<strong>ul#long</strong> will select <strong>&lt;ul id="long"&gt;</strong>, but <strong>#long</strong> is shorter and also selects the same element. You don\'t have to qualify your ids with other selectors.'
     ],
     board: "{)()[]"
   },
@@ -117,7 +117,8 @@ var levels = [
     syntax : "*",
     help : 'You can select all elements with the universal selector! ',
     examples : [
-      '<strong>p *</strong> will select every element inside all <strong>&lt;p&gt;</strong> elements.'
+      '<strong>p *</strong> will select every element inside all <strong>&lt;p&gt;</strong> elements.',
+      'Use sparingly! This selector can hurt performance.' 
     ],
     board: "A(o)[][O]{)"
   },


### PR DESCRIPTION
Level 21: 

Change first instance of #fancy plate to be a bento box.  Why? 

1) We shouldn't encourage devs to have multiple elements with same ID in dom. 

2) This now visually demonstrates how the counting works
    board: "(1)(2)[x](3){4}(5)"
instead of
    board:"(1)(2)[3](4){5}(6)"

This nuance is lost when the third element is another fancybox, since the counting remains the same. 

Level 3:

Add in some text explaining that ul#long is redundant, and that you can just use #long.  Qualifying ids less performant, and shouldn't be encouraged 

Level 10:

Add in a short warning about using the \* selector.  Since CSS is read right-to-left, this ends up querying all elements in the DOM, and can be detrimental to page speed.  A short warning about this was merited. 

I'm not sure if Level 3 and Level 10 changes are what you wanted the focus of CSS Diner to be.  There's a lot of quirks/quick tips that _could_ be provided in this format, but it was kept relatively clean and devoid of commentary. 
