### PR TITLE
fixed double word and mispelling on lesson 3

### DIFF
--- a/levels.js
+++ b/levels.js
@@ -43,7 +43,7 @@ var levels = [
     selectorName: "ID Selector",
     helpTitle: "Select elements with an ID",
     syntax: "#id",
-    help : 'Selects all elemoents element with that <strong>id</strong> attribute. You can also combine the ID selector with the type selector.',
+    help : 'Selects the element with that <strong>id</strong> attribute. You can also combine the ID selector with the type selector.',
     examples : [
       '<strong>#cool</strong> will select any element with <strong>id="cool"</strong>',
       '<strong>ul#long</strong> will select <strong>&lt;ul id="long"&gt;</strong>'


### PR DESCRIPTION
line 46 "all eleoments element" was a dupe and mispelled. replaced with "the element". ID should be unique so all did not apply.
